### PR TITLE
Remove Runtime rfc to use installed in proj.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 RzR
+Copyright (c) 2022-2023 RzR
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,3 +2,5 @@
 -> Added support for net framework 4.0+.<br />
 ### **1.0.2.1848** 
 -> Cleaned up code, and added `System.Runtime` reference.<br />
+### **1.0.3.0959** 
+-> Removed `System.Runtime` reference to use current installed in project. In special for old projects where was added another references with old version (ex. 4.1.0 and in current package uses 4.3.0 -> on adding reference to another project, on publish will be error).<br />

--- a/src/CodeSource/CodeSource.csproj
+++ b/src/CodeSource/CodeSource.csproj
@@ -48,30 +48,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties BuildVersion_StartDate="2022/12/20" />

--- a/src/shared/GeneralAssemblyInfo.cs
+++ b/src/shared/GeneralAssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Resources;
 
 [assembly: AssemblyCompany("RzR ®")]
 [assembly: AssemblyProduct("Code source attribute")]
-[assembly: AssemblyCopyright("Copyright © 2022 RzR All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © 2022-2023 RzR All rights reserved.")]
 [assembly: AssemblyTrademark("® RzR™")]
 [assembly: AssemblyDescription("Provide an easy, accurate, and organized solution for storing data in your source code about some ideas, comments, or code references, which was an inspiration for realizing your current functionality.")]
 
@@ -44,6 +44,6 @@ using System.Resources;
 [assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.MainAssembly)]
 #endif
 
-[assembly: AssemblyVersion("1.0.2.1848")]
-[assembly: AssemblyFileVersion("1.0.2.1848")]
-[assembly: AssemblyInformationalVersion("1.0.2.x")]
+[assembly: AssemblyVersion("1.0.3.0959")]
+[assembly: AssemblyFileVersion("1.0.3.0959")]
+[assembly: AssemblyInformationalVersion("1.0.3.x")]


### PR DESCRIPTION
Removed `System.Runtime` reference to use current installed in project. In special for old projects where was added another references with old version (ex. 4.1.0 and in current package uses 4.3.0 -> on adding reference to another project, on publish will be error).